### PR TITLE
Fixed the Update Site Name

### DIFF
--- a/ac.soton.eventb.emf.inclusion.feature/feature.properties
+++ b/ac.soton.eventb.emf.inclusion.feature/feature.properties
@@ -26,7 +26,10 @@ This feature provides the EMF Inclusion framework for Event-B.\n\
 \n\
 Release history\n\
 ---------------\n\
+### 2.0.2 Maintenance release ###\n\
+- Fixed Update Site name to "Soton Plug-ins".\n\
 ### 2.0.1 Maintenance release ###\n\
+#### Updated Plug-ins ####\n\
 - Event-B EMF Inclusion (2.0.1):\n\
   + Use EPL v2.0 instead of EPL v1.0.\n\
 - Event-B EMF Inclusion Edit (1.0.2):\n\
@@ -36,6 +39,7 @@ Release history\n\
   + Issue #18: Inclusion generator causes Rodin files disappeared.\n\
 ### 2.0.0 Bump version number due to incorrect build in 1.0.0 ###\n\
 Removed unused dependencies\n\
+#### Updated Plug-ins ####\n\
 - Event-B EMF Inclusion (2.0.0):\n\
   + remove copy of bin from build - causes API analysis problem \n\
 - Event-B EMF Inclusion Edit (1.0.1):\n\
@@ -43,6 +47,7 @@ Removed unused dependencies\n\
 - Event-B EMF Inclusion Generator (0.2.2):\n\
   + remove copy of bin from build - causes API analysis problem \n\
 ### 1.0.0. Updated dependency to Event-B EMF Core ###\n\
+#### Updated Plug-ins ####\n\
 - Event-B EMF Inclusion (1.0.0):\n\
   + Updated dependency on Event-B EMF Core to [5.0.0, 6.0.0)\n\
   + Minor internal changes (to be compatible with Java 1.9)\n\
@@ -57,6 +62,7 @@ Removed unused dependencies\n\
 - Event-B EMF Inclusion feature: Modernised the release history.\n\
 \n\
 ### 0.2.0. Implementation changed for Machine Inclusion and Event Synchronisation ###\n\
+#### Updated Plug-ins ####\n\
 - Event-B EMF Inclusion Editor (0.2.0): Fixed provider name\n\
 - Event-B EMF Inclusion Generator (0.2.0):\n\
   + Changed the implementation of Machine Inclusion translation rule\n\
@@ -64,6 +70,7 @@ Removed unused dependencies\n\
  machine inclusion\n\
 \n\
 ### 0.1.0 Initial version ###\n\
+#### Updated Plug-ins ####\n\
 - Event-B EMF Inclusion (0.1.0): Event-B EMF Inclusion Meta-model\
  (Initial version)\n\
 - Event-B EMF Inclusion Edit (0.1.0): Event-B EMF Inclusion Edit Support\
@@ -77,4 +84,4 @@ Removed unused dependencies\n\
 featureCopyright=Copyright (c) 2017, 2021 University of Southampton. All rights reserved.
 
 # "updateSiteName" property - name of the update site
-updateSiteName=UML-B and CamilleX Update Site
+updateSiteName=Soton Plug-ins

--- a/ac.soton.eventb.emf.inclusion.feature/feature.xml
+++ b/ac.soton.eventb.emf.inclusion.feature/feature.xml
@@ -15,7 +15,7 @@
 <feature
       id="ac.soton.eventb.emf.inclusion.feature"
       label="%featureName"
-      version="2.0.2.qualifier"
+      version="2.0.2.release"
       provider-name="%featureVendor"
       license-feature="org.rodinp.licence"
       license-feature-version="1.0.0.release">

--- a/ac.soton.eventb.emf.inclusion.feature/feature.xml
+++ b/ac.soton.eventb.emf.inclusion.feature/feature.xml
@@ -15,7 +15,7 @@
 <feature
       id="ac.soton.eventb.emf.inclusion.feature"
       label="%featureName"
-      version="2.0.1.release"
+      version="2.0.2.qualifier"
       provider-name="%featureVendor"
       license-feature="org.rodinp.licence"
       license-feature-version="1.0.0.release">

--- a/ac.soton.eventb.emf.inclusion.sdk/feature.properties
+++ b/ac.soton.eventb.emf.inclusion.sdk/feature.properties
@@ -33,7 +33,13 @@ tests.\n\
 Release history\n\
 ---------------\n\
 \n\
+### 0.0.4 Fixed Update Site Name ###\n\
+- Change the Update Site to "Soton Plug-ins".\n\
+#### Updated Plug-ins/Features ####\n\
+- Event-B EMF Inclusion Feature (2.0.2)\n\
+- Event-B EMF Inclusion Tests Feature (0.0.4)\n\
 ### 2.0.1 Maintenance release ###\n\
+#### Updated Plug-ins/Features ####\n\
 - Event-B EMF Inclusion Feature (2.0.1)\n\
 - Event-B EMF Inclusion Source (2.0.1): Generated\n\
 - Event-B EMF Inclusion Edit Source (1.0.2): Generated\n\
@@ -42,6 +48,7 @@ Release history\n\
 - Event-B EMF Inclusion Tests Source (0.1.1): Generated\n\
 ### 2.0.0 Bump major version due to incorrect build in 1.0.0 ###\n\
 Also generate source plug-ins instead of source features\n\
+#### Updated Plug-ins/Features ####\n\
 - Event-B EMF Inclusion Feature (2.0.0)\n\
 - Event-B EMF Inclusion Tests Feature (0.1.0) \n\
 - Event-B EMF Inclusion Source (2.0.0): Generated\n\
@@ -49,14 +56,16 @@ Also generate source plug-ins instead of source features\n\
 - Event-B EMF Inclusion Generator Source (0.2.2): Generated\n\
 - Event-B EMF Inclusion Tests Source (0.1.-): Generated\n\
 ### 1.0.0 Updated dependency to Event-B EMF Core ###\n\
+#### Updated Plug-ins/Features ####\n\
 - Event-B EMF Inclusion Feature (1.0.0)\n\
 - Event-B EMF Inclusion Source Feature (1.0.0): Generated\n\
 - Event-B EMF Inclusion Tests Feature (0.0.1): Initial version\n\
 - Event-B EMF Inclusion Tests Source Feature (0.0.1): Generated\n\
 ### 0.2.0. Implementation changed for Machine Inclusion and Event Synchronisation ###\n\
+#### Updated Plug-ins/Features ####\n\
 - Event-B EMF Inclusion Feature (0.2.0)\n\
 - Event-B EMF Inclusion Source Feature (0.2.0): Generated\n\
-### 0.1.0 Initial version ###
+### 0.1.0 Initial version ###\n\
 - Event-B EMF Inclusion Feature (0.1.0): Initial version\n\
 - Event-B EMF Inclusion Source Feature (0.1.0): Generated
   
@@ -64,4 +73,4 @@ Also generate source plug-ins instead of source features\n\
 featureCopyright=Copyright (c) 2017, 2021 University of Southampton. All rights reserved.
 
 # "updateSiteName" property - name of the update site
-updateSiteName=UML-B and CamilleX Update Site
+updateSiteName=Soton Plug-ins

--- a/ac.soton.eventb.emf.inclusion.sdk/feature.xml
+++ b/ac.soton.eventb.emf.inclusion.sdk/feature.xml
@@ -15,7 +15,7 @@
 <feature
       id="ac.soton.eventb.emf.inclusion.sdk"
       label="%featureName"
-      version="2.0.2.qualifier"
+      version="2.0.2.release"
       provider-name="%featureVendor"
       license-feature="org.rodinp.licence"
       license-feature-version="1.0.0.release">

--- a/ac.soton.eventb.emf.inclusion.sdk/feature.xml
+++ b/ac.soton.eventb.emf.inclusion.sdk/feature.xml
@@ -15,7 +15,7 @@
 <feature
       id="ac.soton.eventb.emf.inclusion.sdk"
       label="%featureName"
-      version="2.0.1.release"
+      version="2.0.2.qualifier"
       provider-name="%featureVendor"
       license-feature="org.rodinp.licence"
       license-feature-version="1.0.0.release">

--- a/ac.soton.eventb.emf.inclusion.tests.feature/feature.properties
+++ b/ac.soton.eventb.emf.inclusion.tests.feature/feature.properties
@@ -26,17 +26,22 @@ This feature provides the tests for the EMF Inclusion framework.\n\
 Release history\n\
 ---------------\n\
 \n\
+### 0.0.4 Fixed Update Site Name ###\n\
+- Change the Update Site to "Soton Plug-ins".\n\
 ### 0.0.3 Change Update Site ###\n\
 - Change the Update Site to "UML-B and CamilleX Update Site".\n\
+#### Updated Plug-ins ####\n\
 - Event-B EMF Inclusion Tests (0.1.1): Use EPL 2.0\n\
 ### 0.0.2 Increase version number due to change in the main plug-ins ###\n\
+#### Updated Plug-ins ####\n\
 - Event-B EMF Inclusion Tests (0.0.2): Changes due to version number bump in \
 the main plug-ins.\n\
 ### 0.0.1 Initial version ###\n\
+#### Updated Plug-ins ####\n\
 - Event-B EMF Inclusion Tests (0.0.1): Initial version
   
 # "copyright" property - copyright of the feature
 featureCopyright=Copyright (c) 2017, 2021 University of Southampton. All rights reserved.
 
 # "updateSiteName" property - name of the update site
-updateSiteName=UML-B and CamilleX Update Site
+updateSiteName=Soton Plug-ins

--- a/ac.soton.eventb.emf.inclusion.tests.feature/feature.xml
+++ b/ac.soton.eventb.emf.inclusion.tests.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.emf.inclusion.tests.feature"
       label="%featureName"
-      version="0.0.3.release"
+      version="0.0.4.qualifier"
       provider-name="%featureVendor"
       license-feature="org.rodinp.licence"
       license-feature-version="1.0.0.release">

--- a/ac.soton.eventb.emf.inclusion.tests.feature/feature.xml
+++ b/ac.soton.eventb.emf.inclusion.tests.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.emf.inclusion.tests.feature"
       label="%featureName"
-      version="0.0.4.qualifier"
+      version="0.0.4.release"
       provider-name="%featureVendor"
       license-feature="org.rodinp.licence"
       license-feature-version="1.0.0.release">


### PR DESCRIPTION
The Update Site Name is now "Soton Plug-ins" as consistent with the Rodin Platform